### PR TITLE
Fix/various

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This software is built on the Robotic Operating System ([ROS]), which needs to b
 - [kindr](http://github.com/ethz-asl/kindr) (kinematics and dynamics library for robotics),
 - [Grid Map](https://github.com/ethz-asl/grid_map) (grid map library for mobile robots),
 - [Elevation Map](https://github.com/ethz-asl/elevation_mapping) (elevation mapping with a mobile robot),
+- [Param IO](https://bitbucket.org/leggedrobotics/any_node/src/master/) (Wrapper for the ROS param get and set functions)
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This is the main Traversability Estimation node. It uses the elevation map and t
 
 * **`map_frame_id`** (string, default: "map")
 	
-	The id of the tf frame of the traversability map.
+	The id of the tf frame of the traversability map. This id must be the same as the input elevation submap.
 
 * **`update_rate`** (double, default: 4.0)
 	

--- a/traversability_estimation/CMakeLists.txt
+++ b/traversability_estimation/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   sensor_msgs
   param_io
+  xmlrpcpp
 )
 
 ## System dependencies are found with CMake's conventions
@@ -66,6 +67,7 @@ catkin_package(
     geometry_msgs
     sensor_msgs
     param_io
+    xmlrpcpp
 #  DEPENDS Eigen
 )
 

--- a/traversability_estimation/CMakeLists.txt
+++ b/traversability_estimation/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   geometry_msgs
   sensor_msgs
+  param_io
 )
 
 ## System dependencies are found with CMake's conventions
@@ -64,6 +65,7 @@ catkin_package(
     std_msgs
     geometry_msgs
     sensor_msgs
+    param_io
 #  DEPENDS Eigen
 )
 

--- a/traversability_estimation/config/robot.yaml
+++ b/traversability_estimation/config/robot.yaml
@@ -1,5 +1,5 @@
 submap_service: "/elevation_mapping_long_range/get_submap"
-map_frame_id: "map"
+map_frame_id: "map"     # Must be the same as the input elevation submap.
 robot_frame_id: "base"
 min_update_rate: 0.2
 map_center_x: 0.0

--- a/traversability_estimation/config/robot_footprint_parameter.yaml
+++ b/traversability_estimation/config/robot_footprint_parameter.yaml
@@ -6,3 +6,5 @@ footprint:
   circular_footprint_offset: 0.15
   footprint_frame_id: base
   traversability_default: 0.3
+  verify_roughness_footprint: false
+  check_robot_inclination: false

--- a/traversability_estimation/include/traversability_estimation/TraversabilityEstimation.hpp
+++ b/traversability_estimation/include/traversability_estimation/TraversabilityEstimation.hpp
@@ -189,9 +189,6 @@ class TraversabilityEstimation
   //! Center point of the requested map.
   geometry_msgs::PointStamped submapPoint_;
 
-  //! Id of the frame of the elevation map.
-  std::string mapFrameId_;
-
   //! Id of the frame of the robot.
   std::string robotFrameId_;
 

--- a/traversability_estimation/package.xml
+++ b/traversability_estimation/package.xml
@@ -25,6 +25,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>param_io</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
@@ -39,5 +40,6 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>param_io</run_depend>
 
 </package>

--- a/traversability_estimation/package.xml
+++ b/traversability_estimation/package.xml
@@ -26,6 +26,7 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>param_io</build_depend>
+  <build_depend>xmlrpcpp</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
@@ -41,5 +42,6 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>param_io</run_depend>
+  <run_depend>xmlrpcpp</run_depend>
 
 </package>

--- a/traversability_estimation/src/TraversabilityEstimation.cpp
+++ b/traversability_estimation/src/TraversabilityEstimation.cpp
@@ -77,7 +77,6 @@ bool TraversabilityEstimation::readParameters()
   nodeHandle_.param("image_position_x", imagePosition_.x(), 0.0);
   nodeHandle_.param("image_position_y", imagePosition_.y(), 0.0);
 
-  nodeHandle_.param("map_frame_id", mapFrameId_, string("map"));
   nodeHandle_.param("robot_frame_id", robotFrameId_, string("robot"));
   nodeHandle_.param("robot", robot_, string("robot"));
   nodeHandle_.param("package", package_, string("traversability_estimation"));
@@ -168,7 +167,7 @@ bool TraversabilityEstimation::updateServiceCallback(grid_map_msgs::GetGridMapIn
   grid_map_msgs::GridMap msg;
   grid_map::GridMap traversabilityMap = traversabilityMap_.getTraversabilityMap();
 
-  response.info.header.frame_id = mapFrameId_;
+  response.info.header.frame_id = traversabilityMap_.getMapFrameId();
   response.info.header.stamp = ros::Time::now();
   response.info.resolution = traversabilityMap.getResolution();
   response.info.length_x = traversabilityMap.getLength()[0];
@@ -239,7 +238,7 @@ bool TraversabilityEstimation::requestElevationMap(grid_map_msgs::GridMap& map)
   geometry_msgs::PointStamped submapPointTransformed;
 
   try {
-    transformListener_.transformPoint(mapFrameId_, submapPoint_,
+    transformListener_.transformPoint(traversabilityMap_.getMapFrameId(), submapPoint_,
                                       submapPointTransformed);
   } catch (tf::TransformException &ex) {
     ROS_ERROR("%s", ex.what());

--- a/traversability_estimation/src/TraversabilityEstimation.cpp
+++ b/traversability_estimation/src/TraversabilityEstimation.cpp
@@ -8,6 +8,7 @@
 
 #include "traversability_estimation/TraversabilityEstimation.hpp"
 #include <traversability_msgs/TraversabilityResult.h>
+#include <param_io/get_param.hpp>
 
 // ROS
 #include <ros/package.h>
@@ -60,40 +61,44 @@ TraversabilityEstimation::~TraversabilityEstimation()
 
 bool TraversabilityEstimation::readParameters()
 {
-  nodeHandle_.param("submap_service", submapServiceName_, string("/get_grid_map"));
+  submapServiceName_ = param_io::param<std::string>(nodeHandle_, "submap_service", "/get_grid_map");
 
   double updateRate;
-  nodeHandle_.param("min_update_rate", updateRate, 1.0);
+  updateRate = param_io::param(nodeHandle_, "min_update_rate", 1.0);
   if (updateRate != 0.0) {
     updateDuration_.fromSec(1.0 / updateRate);
   } else {
     updateDuration_.fromSec(0.0);
   }
   // Read parameters for image subscriber.
-  nodeHandle_.param("image_topic", imageTopic_, std::string("/image_elevation"));
-  nodeHandle_.param("resolution", imageResolution_, 0.03);
-  nodeHandle_.param("min_height", imageMinHeight_, 0.0);
-  nodeHandle_.param("max_height", imageMaxHeight_, 1.0);
-  nodeHandle_.param("image_position_x", imagePosition_.x(), 0.0);
-  nodeHandle_.param("image_position_y", imagePosition_.y(), 0.0);
+  imageTopic_ = param_io::param<std::string>(nodeHandle_, "image_topic", "/image_elevation");
+  imageResolution_ = param_io::param(nodeHandle_, "resolution", 0.03);
+  imageMinHeight_ = param_io::param(nodeHandle_, "min_height", 0.0);
+  imageMaxHeight_ = param_io::param(nodeHandle_, "max_height", 1.0);
+  imagePosition_.x() = param_io::param(nodeHandle_, "image_position_x", 0.0);
+  imagePosition_.y() = param_io::param(nodeHandle_, "image_position_y", 0.0);
 
-  nodeHandle_.param("robot_frame_id", robotFrameId_, string("robot"));
-  nodeHandle_.param("robot", robot_, string("robot"));
-  nodeHandle_.param("package", package_, string("traversability_estimation"));
+  robotFrameId_ = param_io::param<std::string>(nodeHandle_, "robot_frame_id", "robot");
+  robot_ = param_io::param<std::string>(nodeHandle_, "robot", "robot");
+  package_ = param_io::param<std::string>(nodeHandle_, "package", "traversability_estimation");
+
   grid_map::Position mapCenter;
-  nodeHandle_.param("map_center_x", mapCenter.x(), 0.0);
-  nodeHandle_.param("map_center_y", mapCenter.y(), 0.0);
+  mapCenter.x() = param_io::param(nodeHandle_, "map_center_x", 0.0);
+  mapCenter.y() = param_io::param(nodeHandle_, "map_center_y", 0.0);
+
   submapPoint_.header.frame_id = robotFrameId_;
   submapPoint_.point.x = mapCenter.x();
-  submapPoint_.point.y = mapCenter.y();
-  submapPoint_.point.z = 0.0;
-  nodeHandle_.param("map_length_x", mapLength_.x(), 5.0);
-  nodeHandle_.param("map_length_y", mapLength_.y(), 5.0);
-  nodeHandle_.param("footprint_yaw", footprintYaw_, M_PI_2);
 
-  nodeHandle_.param("elevation_map/topic", bagTopicName_,  std::string("grid_map"));
-  nodeHandle_.param("elevation_map/load/path_to_bag", pathToLoadBag_, std::string("elevation_map.bag"));
-  nodeHandle_.param("traversability_map/save/path_to_bag", pathToSaveBag_, std::string("traversability_map.bag"));
+  submapPoint_.point.y = mapCenter.y();
+
+  submapPoint_.point.z = 0.0;
+  mapLength_.x() = param_io::param(nodeHandle_, "map_length_x", 5.0);
+  mapLength_.y() = param_io::param(nodeHandle_, "map_length_y", 5.0);
+  footprintYaw_ = param_io::param(nodeHandle_, "footprint_yaw", M_PI_2);
+
+  bagTopicName_ = param_io::param<std::string>(nodeHandle_, "elevation_map/topic", "grid_map");
+  pathToLoadBag_ = param_io::param<std::string>(nodeHandle_, "elevation_map/load/path_to_bag", "elevation_map.bag");
+  pathToSaveBag_ = param_io::param<std::string>(nodeHandle_, "traversability_map/save/path_to_bag", "traversability_map.bag");
 
   return true;
 }

--- a/traversability_estimation/src/TraversabilityMap.cpp
+++ b/traversability_estimation/src/TraversabilityMap.cpp
@@ -99,6 +99,11 @@ bool TraversabilityMap::readParameters()
 
 bool TraversabilityMap::setElevationMap(const grid_map_msgs::GridMap& msg)
 {
+  if (getMapFrameId() != msg.info.header.frame_id) {
+    ROS_ERROR("Received elevation map has frame_id = '%s', but an elevation map with frame_id = '%s' is expected.",
+              msg.info.header.frame_id.c_str(), getMapFrameId().c_str());
+    return false;
+  }
   grid_map::GridMap elevationMap;
   grid_map::GridMapRosConverter::fromMessage(msg, elevationMap);
   zPosition_ = msg.info.pose.position.z;
@@ -367,7 +372,7 @@ bool TraversabilityMap::checkFootprintPath(
     }
   } else {
     grid_map::Polygon polygon, polygon1, polygon2;
-    polygon1.setFrameId(mapFrameId_);
+    polygon1.setFrameId(getMapFrameId());
     polygon1.setTimestamp(ros::Time::now().toNSec());
     polygon2 = polygon1;
     for (int i = 0; i < arraySize; i++) {
@@ -431,7 +436,7 @@ bool TraversabilityMap::checkFootprintPath(
 
       if (arraySize > 1 && i > 0) {
         polygon = grid_map::Polygon::convexHull(polygon1, polygon2);
-        polygon.setFrameId(mapFrameId_);
+        polygon.setFrameId(getMapFrameId());
         polygon.setTimestamp(ros::Time::now().toNSec());
         if (checkRobotInclination_) {
           if (!checkInclination(start, end))

--- a/traversability_estimation/src/TraversabilityMap.cpp
+++ b/traversability_estimation/src/TraversabilityMap.cpp
@@ -23,6 +23,9 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+// Param IO
+#include <param_io/get_param.hpp>
+
 using namespace std;
 
 namespace traversability_estimation {
@@ -83,12 +86,12 @@ bool TraversabilityMap::readParameters()
     ROS_WARN("Traversability Map: No footprint polygon defined.");
   }
 
-  nodeHandle_.param("map_frame_id", mapFrameId_, string("map"));
-  nodeHandle_.param("footprint/traversability_default", traversabilityDefault_, 0.5);
-  nodeHandle_.param("footprint/verify_roughness_footprint", checkForRoughness_, false);
-  nodeHandle_.param("footprint/check_robot_inclination", checkRobotInclination_, false);
-  nodeHandle_.param("max_gap_width", maxGapWidth_, 0.3);
-  nodeHandle_.param("traversability_map_filters/stepFilter/critical_value", criticalStepHeight_, 0.12);
+  mapFrameId_ = param_io::param<std::string>(nodeHandle_, "map_frame_id", "map");
+  traversabilityDefault_ = param_io::param(nodeHandle_, "footprint/traversability_default", 0.5);
+  checkForRoughness_ = param_io::param(nodeHandle_, "footprint/verify_roughness_footprint", false);
+  checkRobotInclination_ = param_io::param(nodeHandle_, "footprint/check_robot_inclination", false);
+  maxGapWidth_ = param_io::param(nodeHandle_, "max_gap_width", 0.3);
+  criticalStepHeight_ = param_io::param(nodeHandle_, "traversability_map_filters/stepFilter/critical_value", 0.12);
 
   // Configure filter chain
   if (!filter_chain_.configure("traversability_map_filters", nodeHandle_)) {


### PR DESCRIPTION
- Use param_io to catch usage of default value. Especially useful when traversability_estimation is used along traversability_planner.
- Use of getter `getMapFrameId()` wherever possibile. 

@martiwer 