### PR TITLE
Rosparam to load elevation map and save traversability map

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,40 +110,40 @@ This is the main Traversability Estimation node. It uses the elevation map and t
 
         rosservice call /traversability_estimation/traversability_footprint
 
-* **`save_to_bag`** ([std_srvs/Empty])
+* **`save_traversability_map_to_bag`** ([std_srvs/Empty])
 
     Save all layers of the current traversability map to a [rosbag] file. Save the traversability map with
 
-        rosservice call /traversability_estimation/save_to_bag
+        rosservice call /traversability_estimation/save_traversability_map_to_bag
 
 #### Parameters
 
 * **`submap_service`** (string, default: "/elevation_mapping/get_grid_map")
 
 	The name of the service to get the elevation submap.
-	
+
 * **`robot_frame_id`** (string, default: "base")
-	
+
 	The id of the robot tf frame.
 
 * **`map_frame_id`** (string, default: "map")
-	
+
 	The id of the tf frame of the traversability map. This id must be the same as the input elevation submap.
 
 * **`update_rate`** (double, default: 4.0)
-	
+
 	The update rate (in \[Hz\]) at which the traversability map is updated.
 
 * **`map_center_x`, `map_center_y`** (double, default: 1.5, 0.0)
-	
+
 	The position of the traversability map (center) in the traversability map frame.
 
 * **`map_length_x`, `map_length_y`** (double, default: 5.0)
-	
+
 	The size (in \[m\]) of the traversability map.
 
 * **`traversability_map_filters:`** (filter_chain)
-	
+
 	Defines the different filters that are used to generate the traversability map.
 
 ### Traversability Estimation Filters

--- a/traversability_estimation/include/traversability_estimation/TraversabilityEstimation.hpp
+++ b/traversability_estimation/include/traversability_estimation/TraversabilityEstimation.hpp
@@ -221,9 +221,12 @@ class TraversabilityEstimation
   TraversabilityMap traversabilityMap_;
 
   //! Path and topic to load elevation map.
-  std::string pathToLoadBag_;
-  std::string pathToSaveBag_;
-  std::string bagTopicName_;
+  std::string pathElevationMapBagToLoad_;
+  std::string elevationMapBagToLoadTopicName_;
+
+  //! Path and topic to save traversability map.
+  std::string pathToSaveTraversabilityMapBag_;
+  std::string traversabilityMapBagTopicName_;
 
   //! Package name where the parameters are defined.
   std::string package_;

--- a/traversability_estimation/launch/traversability_estimation.launch
+++ b/traversability_estimation/launch/traversability_estimation.launch
@@ -7,5 +7,6 @@
     <param name="elevation_map/load/topic" value="grid_map"/>
     <param name="elevation_map/load/path_to_bag" value="$(find traversability_estimation)/maps/elevation_map.bag"/>
     <param name="traversability_map/save/path_to_bag" value="$(find traversability_estimation)/maps/traversability_map.bag"/>
+    <param name="traversability_map/save/topic_name" value="traversability_map"/>
   </node>
 </launch>

--- a/traversability_estimation/launch/traversability_estimation.launch
+++ b/traversability_estimation/launch/traversability_estimation.launch
@@ -4,7 +4,7 @@
     <rosparam command="load" file="$(find traversability_estimation)/config/robot.yaml"/>
     <rosparam command="load" file="$(find traversability_estimation)/config/robot_footprint_parameter.yaml"/>
     <rosparam command="load" file="$(find traversability_estimation)/config/robot_filter_parameter.yaml"/>
-    <param name="elevation_map/topic" value="grid_map"/>
+    <param name="elevation_map/load/topic" value="grid_map"/>
     <param name="elevation_map/load/path_to_bag" value="$(find traversability_estimation)/maps/elevation_map.bag"/>
     <param name="traversability_map/save/path_to_bag" value="$(find traversability_estimation)/maps/traversability_map.bag"/>
   </node>


### PR DESCRIPTION
This PR makes rosparams to load and save rosbags a bit more clear:

- two rosparams can be used to specify the path and topic of an elevation map to load (then a traversability map is automatically computed out of it);
- two rosparams can be used to specify the path and topic where to save the current traversability map.

@martiwer 