### PR TITLE
[traversability_estimation_filters] Replaced deprecated plugin macro.

### DIFF
--- a/traversability_estimation_filters/src/RoughnessFilter.cpp
+++ b/traversability_estimation_filters/src/RoughnessFilter.cpp
@@ -133,5 +133,4 @@ bool RoughnessFilter<T>::update(const T& mapIn, T& mapOut)
 
 } /* namespace */
 
-PLUGINLIB_REGISTER_CLASS(RoughnessFilter, filters::RoughnessFilter<grid_map::GridMap>,
-                         filters::FilterBase<grid_map::GridMap>)
+PLUGINLIB_EXPORT_CLASS(filters::RoughnessFilter<grid_map::GridMap>, filters::FilterBase<grid_map::GridMap>)

--- a/traversability_estimation_filters/src/SlopeFilter.cpp
+++ b/traversability_estimation_filters/src/SlopeFilter.cpp
@@ -90,5 +90,4 @@ bool SlopeFilter<T>::update(const T& mapIn, T& mapOut)
 
 } /* namespace */
 
-PLUGINLIB_REGISTER_CLASS(SlopeFilter, filters::SlopeFilter<grid_map::GridMap>,
-                         filters::FilterBase<grid_map::GridMap>)
+PLUGINLIB_EXPORT_CLASS(filters::SlopeFilter<grid_map::GridMap>, filters::FilterBase<grid_map::GridMap>)

--- a/traversability_estimation_filters/src/StepFilter.cpp
+++ b/traversability_estimation_filters/src/StepFilter.cpp
@@ -183,5 +183,4 @@ bool StepFilter<T>::update(const T& mapIn, T& mapOut)
 
 } /* namespace */
 
-PLUGINLIB_REGISTER_CLASS(StepFilter, filters::StepFilter<grid_map::GridMap>,
-                         filters::FilterBase<grid_map::GridMap>)
+PLUGINLIB_EXPORT_CLASS(filters::StepFilter<grid_map::GridMap>, filters::FilterBase<grid_map::GridMap>)


### PR DESCRIPTION
Backwards compatible. Test were not run yet. If not needed its fine. But will still do that soon.