### PR TITLE
Feature/expose default traversability param

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ This is the main Traversability Estimation node. It uses the elevation map and t
 
 	Defines the different filters that are used to generate the traversability map.
 
+* **`traversability_default`** (double, default: 0.5)
+
+	Defines the default value for traversability of unknown regions in the traversability map.
+
 ### Traversability Estimation Filters
 
 The traversability estimation filters can be applied to an elevation map. Each filter adds an additional layer to the elevation map and computes a value for every cell of the map.

--- a/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
+++ b/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
@@ -129,6 +129,23 @@ class TraversabilityMap
    */
   std::string getMapFrameId() const;
 
+  /*!
+   * Gets the default traversability value of unknown regions in the map.
+   * @return default traversability value of unknown regions in the map
+   */
+  double getDefaultTraversabilityUnknownRegions() const;
+
+  /*!
+   * Sets the default traversability value of unknown regions in the map.
+   * @param[in] defaultTraversability new default traversability value of unknown regions in the map
+    */
+  void setDefaultTraversabilityUknownRegions(const double& defaultTraversability);
+
+  /*!
+   * Restores the default traversability value of unknown regions in the map, which was read during initialization .
+    */
+  void restoreDefaultTraversabilityUknownRegionsReadAtInit();
+
  private:
 
   /*!
@@ -226,6 +243,7 @@ class TraversabilityMap
 
   //! Default value for traversability of unknown regions.
   double traversabilityDefault_;
+  double traversabilityDefaultReadAtInit_;
 
   //! Verify footprint for roughness.
   bool checkForRoughness_;

--- a/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
+++ b/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
@@ -143,12 +143,12 @@ class TraversabilityMap
    * Sets the default traversability value of unknown regions in the map.
    * @param[in] defaultTraversability new default traversability value of unknown regions in the map
     */
-  void setDefaultTraversabilityUknownRegions(const double& defaultTraversability);
+  void setDefaultTraversabilityUnknownRegions(const double &defaultTraversability);
 
   /*!
    * Restores the default traversability value of unknown regions in the map, which was read during initialization .
     */
-  void restoreDefaultTraversabilityUknownRegionsReadAtInit();
+  void restoreDefaultTraversabilityUnknownRegionsReadAtInit();
 
  private:
 

--- a/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
+++ b/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
@@ -29,6 +29,10 @@
 
 namespace traversability_estimation {
 
+// Traversability value bounds.
+constexpr double traversabilityMinValue = 0.0;
+constexpr double traversabilityMaxValue = 1.0;
+
 /*!
  * The terrain traversability estimation core. Updates the traversbility map and
  * evaluates the traversability of single footprints on this map.
@@ -217,6 +221,13 @@ class TraversabilityMap
    * Publishes the footprint polygon.
    */
   void publishFootprintPolygon(const grid_map::Polygon& polygon);
+
+  /*!
+   * Bounds the passed traversability value to respect the allowed bounds.
+   * @param traversabilityValue value to bound.
+   * @return bounder value
+   */
+  double boundTraversabilityValue(const double& traversabilityValue) const;
 
   //! ROS node handle.
   ros::NodeHandle& nodeHandle_;

--- a/traversability_estimation/src/TraversabilityMap.cpp
+++ b/traversability_estimation/src/TraversabilityMap.cpp
@@ -26,6 +26,7 @@
 
 // Param IO
 #include <param_io/get_param.hpp>
+#include <traversability_estimation/TraversabilityMap.hpp>
 
 using namespace std;
 
@@ -88,7 +89,8 @@ bool TraversabilityMap::readParameters()
   }
 
   mapFrameId_ = param_io::param<std::string>(nodeHandle_, "map_frame_id", "map");
-  traversabilityDefault_ = param_io::param(nodeHandle_, "footprint/traversability_default", 0.5);
+  traversabilityDefaultReadAtInit_ = param_io::param(nodeHandle_, "footprint/traversability_default", 0.5);
+  traversabilityDefault_ = traversabilityDefaultReadAtInit_;
   checkForRoughness_ = param_io::param(nodeHandle_, "footprint/verify_roughness_footprint", false);
   checkRobotInclination_ = param_io::param(nodeHandle_, "footprint/check_robot_inclination", false);
   maxGapWidth_ = param_io::param(nodeHandle_, "max_gap_width", 0.3);
@@ -787,6 +789,21 @@ void TraversabilityMap::publishFootprintPolygon(const grid_map::Polygon& polygon
 
 std::string TraversabilityMap::getMapFrameId() const {
   return mapFrameId_;
+}
+
+double TraversabilityMap::getDefaultTraversabilityUnknownRegions() const
+{
+  return traversabilityDefault_;
+}
+
+void TraversabilityMap::setDefaultTraversabilityUknownRegions(const double &defaultTraversability)
+{
+  traversabilityDefault_ = defaultTraversability;
+}
+
+void TraversabilityMap::restoreDefaultTraversabilityUknownRegionsReadAtInit()
+{
+  setDefaultTraversabilityUknownRegions(traversabilityDefaultReadAtInit_);
 }
 
 } /* namespace */

--- a/traversability_estimation/src/TraversabilityMap.cpp
+++ b/traversability_estimation/src/TraversabilityMap.cpp
@@ -92,7 +92,7 @@ bool TraversabilityMap::readParameters()
   traversabilityDefaultReadAtInit_ = param_io::param(nodeHandle_, "footprint/traversability_default", 0.5);
   // Safety check
   traversabilityDefaultReadAtInit_ = boundTraversabilityValue(traversabilityDefaultReadAtInit_);
-  setDefaultTraversabilityUknownRegions(traversabilityDefaultReadAtInit_);
+  setDefaultTraversabilityUnknownRegions(traversabilityDefaultReadAtInit_);
   checkForRoughness_ = param_io::param(nodeHandle_, "footprint/verify_roughness_footprint", false);
   checkRobotInclination_ = param_io::param(nodeHandle_, "footprint/check_robot_inclination", false);
   maxGapWidth_ = param_io::param(nodeHandle_, "max_gap_width", 0.3);
@@ -798,14 +798,14 @@ double TraversabilityMap::getDefaultTraversabilityUnknownRegions() const
   return traversabilityDefault_;
 }
 
-void TraversabilityMap::setDefaultTraversabilityUknownRegions(const double &defaultTraversability)
+void TraversabilityMap::setDefaultTraversabilityUnknownRegions(const double &defaultTraversability)
 {
   traversabilityDefault_ = boundTraversabilityValue(defaultTraversability);
 }
 
-void TraversabilityMap::restoreDefaultTraversabilityUknownRegionsReadAtInit()
+void TraversabilityMap::restoreDefaultTraversabilityUnknownRegionsReadAtInit()
 {
-  setDefaultTraversabilityUknownRegions(traversabilityDefaultReadAtInit_);
+  setDefaultTraversabilityUnknownRegions(traversabilityDefaultReadAtInit_);
 }
 
 double TraversabilityMap::boundTraversabilityValue(const double& traversabilityValue) const

--- a/traversability_estimation/src/TraversabilityMap.cpp
+++ b/traversability_estimation/src/TraversabilityMap.cpp
@@ -90,7 +90,9 @@ bool TraversabilityMap::readParameters()
 
   mapFrameId_ = param_io::param<std::string>(nodeHandle_, "map_frame_id", "map");
   traversabilityDefaultReadAtInit_ = param_io::param(nodeHandle_, "footprint/traversability_default", 0.5);
-  traversabilityDefault_ = traversabilityDefaultReadAtInit_;
+  // Safety check
+  traversabilityDefaultReadAtInit_ = boundTraversabilityValue(traversabilityDefaultReadAtInit_);
+  setDefaultTraversabilityUknownRegions(traversabilityDefaultReadAtInit_);
   checkForRoughness_ = param_io::param(nodeHandle_, "footprint/verify_roughness_footprint", false);
   checkRobotInclination_ = param_io::param(nodeHandle_, "footprint/check_robot_inclination", false);
   maxGapWidth_ = param_io::param(nodeHandle_, "max_gap_width", 0.3);
@@ -798,12 +800,29 @@ double TraversabilityMap::getDefaultTraversabilityUnknownRegions() const
 
 void TraversabilityMap::setDefaultTraversabilityUknownRegions(const double &defaultTraversability)
 {
-  traversabilityDefault_ = defaultTraversability;
+  traversabilityDefault_ = boundTraversabilityValue(defaultTraversability);
 }
 
 void TraversabilityMap::restoreDefaultTraversabilityUknownRegionsReadAtInit()
 {
   setDefaultTraversabilityUknownRegions(traversabilityDefaultReadAtInit_);
+}
+
+double TraversabilityMap::boundTraversabilityValue(const double& traversabilityValue) const
+{
+  if (traversabilityValue > traversabilityMaxValue) {
+    ROS_WARN("Passed traversability value (%f) is higher than max allowed value (%f). It is set equal to the max.",
+             traversabilityValue,
+             traversabilityMaxValue);
+    return traversabilityMaxValue;
+  }
+  if (traversabilityValue < traversabilityMinValue) {
+    ROS_WARN("Passed traversability value (%f) is lower than min allowed value (%f). It is set equal to the min.",
+             traversabilityValue,
+             traversabilityMinValue);
+    return traversabilityMinValue;
+  }
+  return traversabilityValue;
 }
 
 } /* namespace */


### PR DESCRIPTION
This PR allows to set/get/restore the param `traversability_default`.

By changing this parameter, it is possible to change the behavior of a higher level planner about unknown regions in a traversability map. The more `traversability_default` is closer to 0, the less unknown regions are considered when planning. Vice-versa for `traversability_default` closer to 1.

Given parameter for `traversability_default` is checked against constant bounds to make sure it's between 0 and 1.