### PR TITLE
Function to check if 2D pose belongs to current traversability map.

### DIFF
--- a/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
+++ b/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
@@ -150,6 +150,15 @@ class TraversabilityMap
     */
   void restoreDefaultTraversabilityUnknownRegionsReadAtInit();
 
+  /*!
+   * Checks if given 2D pose (x,y) belongs to the traversability layer of the current map.
+   * @param x X coordinate of the 2D pose to check.
+   * @param y Y coordinate of the 2D pose to check.
+   * @return true if pose belongs to the traversability layer of the current map,
+   *              i.e. if there is a valid traversability value in that position.
+   */
+  bool is2DPoseInTraversabilityMap(double x, double y) const;
+
  private:
 
   /*!

--- a/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
+++ b/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
@@ -151,13 +151,12 @@ class TraversabilityMap
   void restoreDefaultTraversabilityUnknownRegionsReadAtInit();
 
   /*!
-   * Checks if given 2D pose (x,y) belongs to the traversability layer of the current map.
-   * @param x X coordinate of the 2D pose to check.
-   * @param y Y coordinate of the 2D pose to check.
-   * @return true if pose belongs to the traversability layer of the current map,
-   *              i.e. if there is a valid traversability value in that position.
+   * Checks if map has a valid traversability value at the specified cell.
+   * @param x X coordinate of the cell to check.
+   * @param y Y coordinate of the cell to check.
+   * @return true if map has a valid traversability value at the specified cell.
    */
-  bool is2DPoseInTraversabilityMap(double x, double y) const;
+  bool mapHasValidTraversabilityAt(double x, double y) const;
 
  private:
 

--- a/traversability_estimation/src/TraversabilityMap.cpp
+++ b/traversability_estimation/src/TraversabilityMap.cpp
@@ -10,6 +10,7 @@
 
 // Grid Map
 #include <grid_map_msgs/GetGridMap.h>
+#include <grid_map_core/GridMap.hpp>
 
 // ROS
 #include <ros/package.h>
@@ -823,6 +824,21 @@ double TraversabilityMap::boundTraversabilityValue(const double& traversabilityV
     return traversabilityMinValue;
   }
   return traversabilityValue;
+}
+
+bool TraversabilityMap::is2DPoseInTraversabilityMap(double x, double y) const
+{
+  grid_map::Position positionToCheck(x, y);
+  grid_map::Index indexToCheck;
+  auto indexObtained = traversabilityMap_.getIndex(positionToCheck, indexToCheck);
+  if (!indexObtained) {
+    ROS_ERROR("It was not possible to get index of the position (%f, %f) in the current grid_map representation of the traversability map.",
+              x,
+              y);
+    return false;
+  }
+
+  return traversabilityMap_.isValid(indexToCheck, traversabilityType_);
 }
 
 } /* namespace */

--- a/traversability_estimation/src/TraversabilityMap.cpp
+++ b/traversability_estimation/src/TraversabilityMap.cpp
@@ -826,7 +826,7 @@ double TraversabilityMap::boundTraversabilityValue(const double& traversabilityV
   return traversabilityValue;
 }
 
-bool TraversabilityMap::is2DPoseInTraversabilityMap(double x, double y) const
+bool TraversabilityMap::mapHasValidTraversabilityAt(double x, double y) const
 {
   grid_map::Position positionToCheck(x, y);
   grid_map::Index indexToCheck;


### PR DESCRIPTION
This PR introduces a public function to check if a 2D pose belongs to the "traversability" layer of the current map. 