### PR TITLE
Feature/accept grid map topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ This is the main Traversability Estimation node. It uses the elevation map and t
 
     	It is possible to subscribe to an image. The image is converted into a grayscale image and the values are mapped into an elevation map.
 
+* **`~/grid_map`** ([grid_map_msgs/GridMap])
+
+      It is possible to subscribe to a grid map. The elevation layer of the input grid map is used to compute the traversability map.
+
 
 #### Published Topics
 
@@ -149,6 +153,14 @@ This is the main Traversability Estimation node. It uses the elevation map and t
 * **`traversability_default`** (double, default: 0.5)
 
 	Defines the default value for traversability of unknown regions in the traversability map.
+
+* **`grid_map_to_initialize_traversability_map/enable`** (bool, default: false)
+
+	Defines if the input topic `~/gird_map` can be accepted to initialize the traversability map.
+
+* **`grid_map_to_initialize_traversability_map/grid_map_topic_name`** (string, default: grid_map)
+
+	Defines the input topic name for the grid map message.
 
 ### Traversability Estimation Filters
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This is the main Traversability Estimation node. It uses the elevation map and t
 
     	It is possible to subscribe to an image. The image is converted into a grayscale image and the values are mapped into an elevation map.
 
-* **`~/grid_map`** ([grid_map_msgs/GridMap])
+* **`~/initial_elevation_map`** ([grid_map_msgs/GridMap])
 
       It is possible to subscribe to a grid map. The elevation layer of the input grid map is used to compute the traversability map.
 
@@ -156,11 +156,11 @@ This is the main Traversability Estimation node. It uses the elevation map and t
 
 * **`grid_map_to_initialize_traversability_map/enable`** (bool, default: false)
 
-	Defines if the input topic `~/grid_map` can be accepted to initialize the traversability map.
+	Defines if the input topic `~/initial_elevation_map` can be accepted to initialize the traversability map.
 
-* **`grid_map_to_initialize_traversability_map/grid_map_topic_name`** (string, default: grid_map)
+* **`grid_map_to_initialize_traversability_map/grid_map_topic_name`** (string, default: initial_elevation_map)
 
-	Defines the input topic name for the grid map message.
+	Defines the input topic name for the grid map message to be used to initialize the traversability map.
 
 ### Traversability Estimation Filters
 

--- a/traversability_estimation/config/robot.yaml
+++ b/traversability_estimation/config/robot.yaml
@@ -10,4 +10,4 @@ footprint_yaw: 0.7854
 max_gap_width: 0.3
 grid_map_to_initialize_traversability_map:
   enable: false
-  grid_map_topic_name: grid_map
+  grid_map_topic_name: initial_elevation_map

--- a/traversability_estimation/config/robot.yaml
+++ b/traversability_estimation/config/robot.yaml
@@ -8,3 +8,6 @@ map_length_x: 4.0
 map_length_y: 4.0
 footprint_yaw: 0.7854
 max_gap_width: 0.3
+grid_map_to_initialize_traversability_map:
+  enable: false
+  grid_map_topic_name: grid_map

--- a/traversability_estimation/include/traversability_estimation/TraversabilityEstimation.hpp
+++ b/traversability_estimation/include/traversability_estimation/TraversabilityEstimation.hpp
@@ -162,18 +162,11 @@ class TraversabilityEstimation
   bool requestElevationMap(grid_map_msgs::GridMap& map);
 
   /*!
-   * Initializes a new traversability map based on the given grid map message. Previous traversability map is overwritten.
-   * @param message grid map message to be used to compute new traversability map.
-   * @return true on success.
-   */
-  bool initializeTraversabilityMapFromGridMapMessage(const grid_map_msgs::GridMap& message);
-
-  /*!
    * Initializes a new traversability map based on the given grid map. Previous traversability map is overwritten.
    * @param gridMap grid map object to be used to compute new traversability map.
    * @return true on success.
    */
-  bool initializeTraversabilityMapFromGridMapMessage(const grid_map::GridMap& gridMap);
+  bool initializeTraversabilityMapFromGridMap(const grid_map::GridMap& gridMap);
 
   //! ROS node handle.
   ros::NodeHandle& nodeHandle_;

--- a/traversability_estimation/include/traversability_estimation/TraversabilityEstimation.hpp
+++ b/traversability_estimation/include/traversability_estimation/TraversabilityEstimation.hpp
@@ -125,6 +125,12 @@ class TraversabilityEstimation
    */
   bool saveToBag(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
 
+  /*!
+   * Callback to receive a grid map message that is used to initialize the traversability map, only if it is not already initialized.
+   * @param message grid map message to be used to initialize the traversability map.
+   */
+  void gridMapToInitTraversabilityMapCallback(const grid_map_msgs::GridMap& message);
+
  private:
 
   /*!
@@ -155,6 +161,20 @@ class TraversabilityEstimation
    */
   bool requestElevationMap(grid_map_msgs::GridMap& map);
 
+  /*!
+   * Initializes a new traversability map based on the given grid map message. Previous traversability map is overwritten.
+   * @param message grid map message to be used to compute new traversability map.
+   * @return true on success.
+   */
+  bool initializeTraversabilityMapFromGridMapMessage(const grid_map_msgs::GridMap& message);
+
+  /*!
+   * Initializes a new traversability map based on the given grid map. Previous traversability map is overwritten.
+   * @param gridMap grid map object to be used to compute new traversability map.
+   * @return true on success.
+   */
+  bool initializeTraversabilityMapFromGridMapMessage(const grid_map::GridMap& gridMap);
+
   //! ROS node handle.
   ros::NodeHandle& nodeHandle_;
 
@@ -176,6 +196,11 @@ class TraversabilityEstimation
   double imageResolution_;
   double imageMinHeight_;
   double imageMaxHeight_;
+
+  //! Grid Map topic to initialize traversability map.
+  ros::Subscriber gridMapToInitTraversabilityMapSubscriber_;
+  std::string gridMapToInitTraversabilityMapTopic_;
+  bool acceptGridMapToInitTraversabilityMap_;
 
   //! Elevation map service client.
   ros::ServiceClient submapClient_;

--- a/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
+++ b/traversability_estimation/include/traversability_estimation/TraversabilityMap.hpp
@@ -285,7 +285,7 @@ class TraversabilityMap
   std::vector<std::string> traversabilityMapLayers_;
   bool traversabilityMapInitialized_;
 
-  //! Traversability map.
+  //! Elevation map.
   grid_map::GridMap elevationMap_;
   std::vector<std::string> elevationMapLayers_;
   bool elevationMapInitialized_;

--- a/traversability_estimation/src/TraversabilityEstimation.cpp
+++ b/traversability_estimation/src/TraversabilityEstimation.cpp
@@ -20,6 +20,7 @@ namespace traversability_estimation {
 
 TraversabilityEstimation::TraversabilityEstimation(ros::NodeHandle& nodeHandle)
     : nodeHandle_(nodeHandle),
+      acceptGridMapToInitTraversabilityMap_(false),
       traversabilityMap_(nodeHandle),
       traversabilityType_("traversability"),
       slopeType_("traversability_slope"),
@@ -47,6 +48,14 @@ TraversabilityEstimation::TraversabilityEstimation(ros::NodeHandle& nodeHandle)
   traversabilityFootprint_ = nodeHandle_.advertiseService("traversability_footprint", &TraversabilityEstimation::traversabilityFootprint, this);
   saveToBagService_ = nodeHandle_.advertiseService("save_traversability_map_to_bag", &TraversabilityEstimation::saveToBag, this);
   imageSubscriber_ = nodeHandle_.subscribe(imageTopic_,1,&TraversabilityEstimation::imageCallback, this);
+
+  if (acceptGridMapToInitTraversabilityMap_) {
+    gridMapToInitTraversabilityMapSubscriber_ =
+        nodeHandle_.subscribe(gridMapToInitTraversabilityMapTopic_,
+                              1,
+                              &TraversabilityEstimation::gridMapToInitTraversabilityMapCallback,
+                              this);
+  }
 
   elevationMapLayers_.push_back("elevation");
   elevationMapLayers_.push_back("upper_bound");
@@ -101,6 +110,11 @@ bool TraversabilityEstimation::readParameters()
   pathToSaveTraversabilityMapBag_ = param_io::param<std::string>(nodeHandle_, "traversability_map/save/path_to_bag", "traversability_map.bag");
   traversabilityMapBagTopicName_ = param_io::param<std::string>(nodeHandle_, "traversability_map/save/topic_name", "traversability_map");
 
+  // Grid map to initialize elevation layer
+  acceptGridMapToInitTraversabilityMap_ = param_io::param<bool>(nodeHandle_, "grid_map_to_initialize_traversability_map/enable", false);
+  gridMapToInitTraversabilityMapTopic_ =
+      param_io::param<std::string>(nodeHandle_, "grid_map_to_initialize_traversability_map/grid_map_topic_name", "elevation_map");
+
   return true;
 }
 
@@ -113,26 +127,14 @@ bool TraversabilityEstimation::loadElevationMap(std_srvs::Empty::Request&, std_s
     ROS_ERROR("TraversabilityEstimation: Cannot find bag or topic of the elevation map!");
     return false;
   }
-  for (auto layer : elevationMapLayers_) {
-    if (!map.exists(layer)) {
-      map.add(layer, 0.0);
-      ROS_INFO_STREAM("TraversabilityEstimation: loadElevationMap: Added layer '" << layer << "'.");
-    }
-  }
-  ROS_DEBUG_STREAM("Map frame id: " << map.getFrameId());
-  for (auto layer : map.getLayers()) {
-    ROS_DEBUG_STREAM("Map layers: " << layer);
-  }
-  ROS_DEBUG_STREAM("Map size: " << map.getLength());
-  ROS_DEBUG_STREAM("Map position: " << map.getPosition());
-  ROS_DEBUG_STREAM("Map resolution: " << map.getResolution());
 
   map.setTimestamp(ros::Time::now().toNSec());
   grid_map::GridMapRosConverter::toMessage(map, msg);
-  traversabilityMap_.setElevationMap(msg);
-  if (!traversabilityMap_.computeTraversability()) {
-    ROS_WARN("TraversabilityEstimation: loadElevationMap: cannot compute traversability.");
-    return false;
+  if (!initializeTraversabilityMapFromGridMapMessage(msg)) {
+    ROS_ERROR(
+        "TraversabilityEstimation: loadElevationMap: it was not possible to load elevation map from bag with path '%s' and topic '%s'.",
+        pathElevationMapBagToLoad_.c_str(),
+        elevationMapBagToLoadTopicName_.c_str());
   }
   return true;
 }
@@ -324,6 +326,57 @@ bool TraversabilityEstimation::saveToBag(std_srvs::Empty::Request& request, std_
   ROS_INFO("Save to bag.");
   return grid_map::GridMapRosConverter::saveToBag(traversabilityMap_.getTraversabilityMap(),
       pathToSaveTraversabilityMapBag_, traversabilityMapBagTopicName_);
+}
+
+bool TraversabilityEstimation::initializeTraversabilityMapFromGridMapMessage(const grid_map_msgs::GridMap& message)
+{
+  grid_map::GridMap gridMap;
+  grid_map::GridMapRosConverter::fromMessage(message, gridMap);
+  return initializeTraversabilityMapFromGridMapMessage(gridMap);
+}
+
+bool TraversabilityEstimation::initializeTraversabilityMapFromGridMapMessage(const grid_map::GridMap &gridMap) {
+  if (traversabilityMap_.traversabilityMapInitialized()) {
+    ROS_WARN(
+        "[TraversabilityEstimation::gridMapToInitTraversabilityMapCallback]: received grid map message cannot be used to initialize"
+        " the traversability map, because current traversability map has been already initialized.");
+    return false;
+  }
+
+  grid_map::GridMap mapWithCheckedLayers = gridMap;
+  for (const auto& layer : elevationMapLayers_) {
+    if (!mapWithCheckedLayers.exists(layer)) {
+      mapWithCheckedLayers.add(layer, 0.0);
+      ROS_INFO_STREAM("[TraversabilityEstimation::initializeTraversabilityMapFromGridMapMessage]: Added layer '" << layer << "'.");
+    }
+  }
+  ROS_DEBUG_STREAM("Map frame id: " << mapWithCheckedLayers.getFrameId());
+  for (const auto& layer : mapWithCheckedLayers.getLayers()) {
+    ROS_DEBUG_STREAM("Map layers: " << layer);
+  }
+  ROS_DEBUG_STREAM("Map size: " << mapWithCheckedLayers.getLength());
+  ROS_DEBUG_STREAM("Map position: " << mapWithCheckedLayers.getPosition());
+  ROS_DEBUG_STREAM("Map resolution: " << mapWithCheckedLayers.getResolution());
+
+  grid_map_msgs::GridMap message;
+  grid_map::GridMapRosConverter::toMessage(mapWithCheckedLayers, message);
+  traversabilityMap_.setElevationMap(message);
+  if (!traversabilityMap_.computeTraversability()) {
+    ROS_WARN("TraversabilityEstimation: initializeTraversabilityMapFromGridMapMessage: cannot compute traversability.");
+    return false;
+  }
+  return true;
+}
+
+void TraversabilityEstimation::gridMapToInitTraversabilityMapCallback(const grid_map_msgs::GridMap& message)
+{
+  if (!initializeTraversabilityMapFromGridMapMessage(message)) {
+      ROS_ERROR("[TraversabilityEstimation::gridMapToInitTraversabilityMapCallback]: "
+                "It was not possible to use received grid map message to initialize traversability map.");
+  } else {
+    ROS_INFO("[TraversabilityEstimation::gridMapToInitTraversabilityMapCallback]: "
+             "Traversability Map initialized using received grid map on topic '%s'.", gridMapToInitTraversabilityMapTopic_.c_str());
+  }
 }
 
 } /* namespace */

--- a/traversability_estimation/src/TraversabilityEstimation.cpp
+++ b/traversability_estimation/src/TraversabilityEstimation.cpp
@@ -335,7 +335,8 @@ bool TraversabilityEstimation::initializeTraversabilityMapFromGridMapMessage(con
   return initializeTraversabilityMapFromGridMapMessage(gridMap);
 }
 
-bool TraversabilityEstimation::initializeTraversabilityMapFromGridMapMessage(const grid_map::GridMap &gridMap) {
+bool TraversabilityEstimation::initializeTraversabilityMapFromGridMapMessage(const grid_map::GridMap &gridMap)
+{
   if (traversabilityMap_.traversabilityMapInitialized()) {
     ROS_WARN(
         "[TraversabilityEstimation::gridMapToInitTraversabilityMapCallback]: received grid map message cannot be used to initialize"

--- a/traversability_estimation/src/TraversabilityEstimation.cpp
+++ b/traversability_estimation/src/TraversabilityEstimation.cpp
@@ -113,7 +113,7 @@ bool TraversabilityEstimation::readParameters()
   // Grid map to initialize elevation layer
   acceptGridMapToInitTraversabilityMap_ = param_io::param<bool>(nodeHandle_, "grid_map_to_initialize_traversability_map/enable", false);
   gridMapToInitTraversabilityMapTopic_ =
-      param_io::param<std::string>(nodeHandle_, "grid_map_to_initialize_traversability_map/grid_map_topic_name", "elevation_map");
+      param_io::param<std::string>(nodeHandle_, "grid_map_to_initialize_traversability_map/grid_map_topic_name", "initial_elevation_map");
 
   return true;
 }

--- a/traversability_estimation/src/TraversabilityMap.cpp
+++ b/traversability_estimation/src/TraversabilityMap.cpp
@@ -50,7 +50,7 @@ TraversabilityMap::TraversabilityMap(ros::NodeHandle& nodeHandle)
   ROS_INFO("Traversability Map started.");
 
   readParameters();
-  traversabilityMapPublisher_ = nodeHandle_.advertise<grid_map_msgs::GridMap>("traversability_map", 1);
+  traversabilityMapPublisher_ = nodeHandle_.advertise<grid_map_msgs::GridMap>("traversability_map", 1, true);
   footprintPublisher_ = nodeHandle_.advertise<geometry_msgs::PolygonStamped>("footprint_polygon", 1, true);
 
   elevationMapLayers_.push_back("elevation");


### PR DESCRIPTION
This PR adds the possibility to accept a grid_map_msgs topic to initialize the traversability map.
Per default the topic `/grid_map` is not subscribed by the node, but if the param `grid_map_to_initialize_traversability_map/enable` is set to true, then a grid map message can be used to init the traversability map.