### PR TITLE
Feature/save load from srv call

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ This is the main Traversability Estimation node. It uses the elevation map and t
 
 #### Services
 
-* **`load_elevation_map`** ([std_srvs/Empty])
+* **`load_elevation_map`** ([grid_map_msgs/ProcessFile])
 
     Trigger the loading of an elevation map from a [rosbag] file. Trigger the loading of the map with
 
-        rosservice call /traversability_estimation/load_elevation_map
+        rosservice call /traversability_estimation/load_elevation_map "file_path: '/home/user/your_elevation_bag.bag' topic_name: 'elevation_topic_name'"
 
 * **`update_traversability`** ([grid_map_msgs/GetGridMapInfo])
 
@@ -114,11 +114,11 @@ This is the main Traversability Estimation node. It uses the elevation map and t
 
         rosservice call /traversability_estimation/traversability_footprint
 
-* **`save_traversability_map_to_bag`** ([std_srvs/Empty])
+* **`save_traversability_map_to_bag`** ([grid_map_msgs/ProcessFile])
 
     Save all layers of the current traversability map to a [rosbag] file. Save the traversability map with
 
-        rosservice call /traversability_estimation/save_traversability_map_to_bag
+        rosservice call /traversability_estimation/save_traversability_map_to_bag "file_path: '/home/user/your_bag.bag' topic_name: 'traversability_map_topic_name'"
 
 #### Parameters
 

--- a/traversability_estimation/include/traversability_estimation/TraversabilityEstimation.hpp
+++ b/traversability_estimation/include/traversability_estimation/TraversabilityEstimation.hpp
@@ -14,6 +14,7 @@
 #include <grid_map_ros/grid_map_ros.hpp>
 #include <grid_map_msgs/GetGridMapInfo.h>
 #include <grid_map_msgs/GetGridMap.h>
+#include <grid_map_msgs/ProcessFile.h>
 
 // Traversability estimation
 #include <traversability_msgs/CheckFootprintPath.h>
@@ -57,8 +58,8 @@ class TraversabilityEstimation
    * @param response the ROS service response.
    * @return true if successful.
    */
-  bool loadElevationMap(std_srvs::Empty::Request& request,
-                       std_srvs::Empty::Response& response);
+  bool loadElevationMap(grid_map_msgs::ProcessFile::Request& request,
+                        grid_map_msgs::ProcessFile::Response& response);
 
   /*!
    * ROS service callback function that forces an update of the traversability map,
@@ -118,12 +119,12 @@ class TraversabilityEstimation
                              grid_map_msgs::GetGridMap::Response& response);
 
   /*!
-   * Saves the grid map with all layer to a ROS bag.
+   * Saves the traversability map with all layers to a ROS bag.
    * @param request the ROS service request.
    * @param response the ROS service response.
    * @return true if successful.
    */
-  bool saveToBag(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
+  bool saveToBag(grid_map_msgs::ProcessFile::Request& request, grid_map_msgs::ProcessFile::Response& response);
 
   /*!
    * Callback to receive a grid map message that is used to initialize the traversability map, only if it is not already initialized.
@@ -244,14 +245,6 @@ class TraversabilityEstimation
 
   //! Traversability map
   TraversabilityMap traversabilityMap_;
-
-  //! Path and topic to load elevation map.
-  std::string pathElevationMapBagToLoad_;
-  std::string elevationMapBagToLoadTopicName_;
-
-  //! Path and topic to save traversability map.
-  std::string pathToSaveTraversabilityMapBag_;
-  std::string traversabilityMapBagTopicName_;
 
   //! Package name where the parameters are defined.
   std::string package_;

--- a/traversability_estimation/launch/traversability_estimation.launch
+++ b/traversability_estimation/launch/traversability_estimation.launch
@@ -4,9 +4,5 @@
     <rosparam command="load" file="$(find traversability_estimation)/config/robot.yaml"/>
     <rosparam command="load" file="$(find traversability_estimation)/config/robot_footprint_parameter.yaml"/>
     <rosparam command="load" file="$(find traversability_estimation)/config/robot_filter_parameter.yaml"/>
-    <param name="elevation_map/load/topic" value="grid_map"/>
-    <param name="elevation_map/load/path_to_bag" value="$(find traversability_estimation)/maps/elevation_map.bag"/>
-    <param name="traversability_map/save/path_to_bag" value="$(find traversability_estimation)/maps/traversability_map.bag"/>
-    <param name="traversability_map/save/topic_name" value="traversability_map"/>
   </node>
 </launch>


### PR DESCRIPTION
This should be the last PR for now.

In this PR rosparams to save and load traversability map are removed and are instead substituted with service calls. The possibility to specify the path of the bag and the topic name for saving/loading a traversability map is now provided.